### PR TITLE
Short hand response

### DIFF
--- a/steinie/app.py
+++ b/steinie/app.py
@@ -25,8 +25,7 @@ class Steinie(routing.Router):
         )(request, response)
         if not isinstance(new_response, wrappers.Response):
             if type(new_response) is tuple:
-                response.status_code = new_response[0]
-                response.data = new_response[1]
+                response.status_code, response.data = new_response[:2]
                 try:
                     for k, v in new_response[2].items():
                         response.headers[k] = v

--- a/steinie/app.py
+++ b/steinie/app.py
@@ -24,9 +24,12 @@ class Steinie(routing.Router):
             self
         )(request, response)
         if not isinstance(new_response, wrappers.Response):
-            if new_response is None:
-                new_response = ""
-            response.data = new_response
+            if type(new_response) is tuple:
+                response.status_code, response.data = new_response
+            else:
+                if new_response is None:
+                    new_response = ""
+                response.data = new_response
         else:
             response = new_response
         return response(environ, start_response)

--- a/steinie/app.py
+++ b/steinie/app.py
@@ -25,7 +25,14 @@ class Steinie(routing.Router):
         )(request, response)
         if not isinstance(new_response, wrappers.Response):
             if type(new_response) is tuple:
-                response.status_code, response.data = new_response
+                response.status_code = new_response[0]
+                response.data = new_response[1]
+                try:
+                    for k, v in new_response[2].items():
+                        response.headers[k] = v
+                except IndexError:
+                    pass
+
             else:
                 if new_response is None:
                     new_response = ""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -36,6 +36,19 @@ class SteinieTest(unittest.TestCase):
             self.assertEqual(201, r.status_code)
             self.assertEqual("Some string", r.content)
 
+    def test_route_can_return_code_plus_string_plus_headers(self):
+        a = app.Steinie()
+
+        @a.get("/")
+        def some_route(req, res):
+            return 201, "Some string", {"X-Steinie": "Hi there!"}
+
+        with utils.run_app(a):
+            r = utils.get("http://localhost:5151/")
+            self.assertEqual(201, r.status_code)
+            self.assertEqual("Some string", r.content)
+            self.assertIn("x-steinie", r.headers)
+
     def test_is_a_route(self):
         a = app.Steinie()
         self.assertIsInstance(a, routing.Router)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,6 +12,30 @@ from . import utils
 
 
 class SteinieTest(unittest.TestCase):
+    def test_route_can_return_string(self):
+        a = app.Steinie()
+
+        @a.get("/")
+        def some_route(req, res):
+            return "Some string"
+
+        with utils.run_app(a):
+            r = utils.get("http://localhost:5151/")
+            self.assertEqual(200, r.status_code)
+            self.assertEqual("Some string", r.content)
+
+    def test_route_can_return_code_plus_string(self):
+        a = app.Steinie()
+
+        @a.get("/")
+        def some_route(req, res):
+            return 201, "Some string"
+
+        with utils.run_app(a):
+            r = utils.get("http://localhost:5151/")
+            self.assertEqual(201, r.status_code)
+            self.assertEqual("Some string", r.content)
+
     def test_is_a_route(self):
         a = app.Steinie()
         self.assertIsInstance(a, routing.Router)


### PR DESCRIPTION
@kennethreitz made a solid case for supporting short-hand returns from the view objects.  This implements that:

``` python
@route.get("/foo")
def handler(request, response):
    return 201, "some response", {"X-Header": "Some Value"}
```

Is the same as:

``` python
@route.get("/foo")
def handler(request, response):
    response.status_code = 201
    response.data = "some response"
    response.headers["X-Header"] = "Some Value"
    return response
```
## Outstanding task
- [x] Code and test
- [ ] Write up an example for docs
